### PR TITLE
Scrum 39 update onboarding model to match personal info model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .env
+.DS_Store

--- a/server/src/config/seedData.ts
+++ b/server/src/config/seedData.ts
@@ -37,24 +37,39 @@ const seedApartments = [
 const seedOnboarding = [
   {
     status: 'approved',
-    name: 'John Doe',
+    name: {
+      firstName: 'John',
+      lastName: 'Doe'
+    },
     gender: 'male',
-    dob: '1985-06-15',
-    address: '123 Main Street, New York, NY',
+    dob: new Date('1985-06-15'),
+    address: {
+      buildingNumber: '123',
+      streetName: 'Main Street',
+      city: 'New York',
+      state: 'NY',
+      zipCode: '10001'
+    },
     phone: {
       work: '555-123-4567',
       cell: '555-987-6543'
     },
-    SSN: 123456789,
+    SSN: '123456789',
     carInfo: {
       make: 'Toyota',
       model: 'Camry',
       color: 'Blue'
     },
-    driversLicense: 'NY123456789',
-    residency: 'citizen',
-    documents: ['passport.pdf', 'SSN_card.jpg'],
-    profilePicture: 'john_doe_profile.jpg',
+    driversLicense: {
+      hasLicense: true,
+      number: 'NY123456789',
+      expirationDate: new Date('2025-01-01'),
+      document: null
+    },
+    employment: {
+      residencyStatus: 'citizen'
+    },
+    profilePicture: null,
     reference: {
       firstName: 'Jane',
       lastName: 'Smith',
@@ -62,55 +77,134 @@ const seedOnboarding = [
       email: 'jane.smith@example.com',
       relationship: 'friend'
     },
-    emergencyContact: {
-      firstName: 'Jane',
-      lastName: 'Smith',
-      phone: '555-444-5555',
-      email: 'jane.smith@example.com',
-      relationship: 'friend'
-    }
+    emergencyContact: [
+      {
+        firstName: 'Mary',
+        lastName: 'Doe',
+        middleName: null,
+        phone: '555-111-2222',
+        email: 'mary.doe@example.com',
+        relationship: 'spouse'
+      },
+      {
+        firstName: 'James',
+        lastName: 'Doe',
+        middleName: null,
+        phone: '555-333-4444',
+        email: 'james.doe@example.com',
+        relationship: 'father'
+      }
+    ]
   },
   {
     status: 'pending',
-    name: 'Jane Smith',
+    name: {
+      firstName: 'Jane',
+      lastName: 'Smith'
+    },
     gender: 'female',
-    dob: '1990-02-28',
-    address: '456 Elm Street, San Francisco, CA',
+    dob: new Date('1990-02-28'),
+    address: {
+      buildingNumber: '456',
+      streetName: 'Elm Street',
+      city: 'San Francisco',
+      state: 'CA',
+      zipCode: '94101'
+    },
     phone: {
       work: '555-222-3333',
       cell: '555-444-5555'
     },
-    SSN: 987654321,
+    SSN: '987654321',
     carInfo: {
       make: 'Honda',
       model: 'Civic',
       color: 'Red'
     },
-    driversLicense: 'CA987654321',
-    residency: 'permanent resident',
-    documents: ['drivers_license.jpg'],
-    profilePicture: 'jane_smith_profile.jpg'
+    driversLicense: {
+      hasLicense: true,
+      number: 'CA987654321',
+      expirationDate: new Date('2024-12-31'),
+      document: null
+    },
+    employment: {
+      residencyStatus: 'greenCard'
+    },
+    profilePicture: null,
+    emergencyContact: [
+      {
+        firstName: 'Robert',
+        lastName: 'Smith',
+        middleName: null,
+        phone: '555-555-6666',
+        email: 'robert.smith@example.com',
+        relationship: 'brother'
+      },
+      {
+        firstName: 'Margaret',
+        lastName: 'Wilson',
+        middleName: null,
+        phone: '555-777-8888',
+        email: 'margaret.wilson@example.com',
+        relationship: 'mother'
+      }
+    ]
   },
   {
     status: 'rejected',
-    name: 'Michael Brown',
-    gender: 'male',
-    dob: '1980-12-05',
-    address: '789 Maple Avenue, Seattle, WA',
-    phone: {
-      work: '555-666-7777',
-      cell: '555-888-9999'
+    name: {
+      firstName: 'Michael',
+      lastName: 'Brown',
+      middleName: 'Conversion',
+      preferredName: 'Test'
     },
-    SSN: 456789123,
+    gender: 'male',
+    dob: new Date('1980-12-05'),
+    address: {
+      buildingNumber: '789',
+      streetName: 'Maple Avenue',
+      city: 'Seattle',
+      state: 'WA',
+      zipCode: '98101'
+    },
+    phone: {
+      cell: '555-999-0000'
+    },
+    SSN: '456789123',
     carInfo: {
       make: 'Ford',
       model: 'Escape',
       color: 'White'
     },
-    driversLicense: 'WA456789123',
-    residency: 'nonresident',
-    documents: ['visa.pdf', 'passport.jpg'],
-    profilePicture: 'michael_brown_profile.jpg'
+    driversLicense: {
+      hasLicense: true,
+      number: 'WA456789123',
+      expirationDate: new Date('2025-06-30'),
+      document: null
+    },
+    employment: {
+      residencyStatus: 'nonresident',
+      visaType: 'H1-B',
+      startDate: new Date('2023-03-01'),
+      endDate: new Date('2024-03-01')
+    },
+    profilePicture: null,
+    emergencyContact: [
+      {
+        firstName: 'Sarah',
+        lastName: 'Brown',
+        phone: '555-999-0000',
+        email: 'sarah.brown@example.com',
+        relationship: 'spouse'
+      },
+      {
+        firstName: 'David',
+        lastName: 'Brown',
+        phone: '555-222-3333',
+        email: 'david.brown@example.com',
+        relationship: 'father'
+      }
+    ]
   }
 ];
 
@@ -169,13 +263,11 @@ const seedPersonalInfo = [
     userId: null,
     name: {
       firstName: 'John',
-      lastName: 'Doe',
-      middleName: null,
-      preferredName: null
+      lastName: 'Doe'
     },
     email: 'john.doe@example.com',
     gender: 'male',
-    dob: '1985-06-15',
+    dob: new Date('1985-06-15'),
     address: {
       buildingNumber: '123',
       streetName: 'Main Street',
@@ -187,12 +279,30 @@ const seedPersonalInfo = [
       work: '555-123-4567',
       cell: '555-987-6543'
     },
-    employment: {
-      residencyStatus: 'citizen',
-      visaType: null,
-      documents: []
+    SSN: '123456789',
+    carInfo: {
+      make: 'Toyota',
+      model: 'Camry',
+      color: 'Blue'
     },
-    emergencyContacts: [
+    driversLicense: {
+      hasLicense: true,
+      number: 'NY123456789',
+      expirationDate: new Date('2025-01-01'),
+      document: null
+    },
+    employment: {
+      residencyStatus: 'citizen'
+    },
+    profilePicture: 'john_profile.jpg',
+    reference: {
+      firstName: 'Jane',
+      lastName: 'Smith',
+      phone: '555-444-5555',
+      email: 'jane.smith@example.com',
+      relationship: 'friend'
+    },
+    emergencyContact: [
       {
         firstName: 'Mary',
         lastName: 'Doe',
@@ -209,31 +319,18 @@ const seedPersonalInfo = [
         email: 'james.doe@example.com',
         relationship: 'father'
       }
-    ],
-    SSN: '123456789',
-    carInfo: {
-      make: 'Toyota',
-      model: 'Camry',
-      color: 'Blue'
-    },
-    driversLicense: {
-      hasLicense: true,
-      number: 'NY123456789',
-      expirationDate: new Date('2025-01-01')
-    }
+    ]
   },
   {
     // based on jane.smith's onboarding data
     userId: null,
     name: {
       firstName: 'Jane',
-      lastName: 'Smith',
-      middleName: null,
-      preferredName: null
+      lastName: 'Smith'
     },
     email: 'jane.smith@example.com',
     gender: 'female',
-    dob: '1990-02-28',
+    dob: new Date('1990-02-28'),
     address: {
       buildingNumber: '456',
       streetName: 'Elm Street',
@@ -245,21 +342,6 @@ const seedPersonalInfo = [
       work: '555-222-3333',
       cell: '555-444-5555'
     },
-    employment: {
-      residencyStatus: 'greenCard',
-      visaType: null,
-      documents: []
-    },
-    emergencyContacts: [
-      {
-        firstName: 'Robert',
-        lastName: 'Smith',
-        middleName: null,
-        phone: '555-555-6666',
-        email: 'robert.smith@example.com',
-        relationship: 'brother'
-      }
-    ],
     SSN: '987654321',
     carInfo: {
       make: 'Honda',
@@ -269,21 +351,42 @@ const seedPersonalInfo = [
     driversLicense: {
       hasLicense: true,
       number: 'CA987654321',
-      expirationDate: new Date('2024-12-31')
-    }
+      expirationDate: new Date('2024-12-31'),
+      document: null
+    },
+    employment: {
+      residencyStatus: 'greenCard'
+    },
+    profilePicture: 'jane_profile.jpg',
+    emergencyContact: [
+      {
+        firstName: 'Robert',
+        lastName: 'Smith',
+        middleName: null,
+        phone: '555-555-6666',
+        email: 'robert.smith@example.com',
+        relationship: 'brother'
+      },
+      {
+        firstName: 'Margaret',
+        lastName: 'Wilson',
+        middleName: null,
+        phone: '555-777-8888',
+        email: 'margaret.wilson@example.com',
+        relationship: 'mother'
+      }
+    ]
   },
   {
     // based on michael.brown's onboarding data
     userId: null,
     name: {
       firstName: 'Michael',
-      lastName: 'Brown',
-      middleName: null,
-      preferredName: null
+      lastName: 'Brown'
     },
     email: 'michael.brown@example.com',
     gender: 'male',
-    dob: '1980-12-05',
+    dob: new Date('1980-12-05'),
     address: {
       buildingNumber: '789',
       streetName: 'Maple Avenue',
@@ -292,34 +395,8 @@ const seedPersonalInfo = [
       zipCode: '98101'
     },
     phone: {
-      work: '555-666-7777',
-      cell: '555-888-9999'
+      cell: '555-999-0000'
     },
-    employment: {
-      residencyStatus: 'nonresident',
-      visaType: 'H1-B',
-      startDate: new Date('2023-03-01'),
-      endDate: new Date('2024-03-01'),
-      documents: []
-    },
-    emergencyContacts: [
-      {
-        firstName: 'Sarah',
-        lastName: 'Brown',
-        middleName: null,
-        phone: '555-777-8888',
-        email: 'sarah.brown@example.com',
-        relationship: 'spouse'
-      },
-      {
-        firstName: 'David',
-        lastName: 'Brown',
-        middleName: null,
-        phone: '555-999-0000',
-        email: 'david.brown@example.com',
-        relationship: 'father'
-      }
-    ],
     SSN: '456789123',
     carInfo: {
       make: 'Ford',
@@ -329,8 +406,32 @@ const seedPersonalInfo = [
     driversLicense: {
       hasLicense: true,
       number: 'WA456789123',
-      expirationDate: new Date('2025-06-30')
-    }
+      expirationDate: new Date('2025-06-30'),
+      document: null
+    },
+    employment: {
+      residencyStatus: 'nonresident',
+      visaType: 'H1-B',
+      startDate: new Date('2023-03-01'),
+      endDate: new Date('2024-03-01')
+    },
+    profilePicture: 'michael_profile.jpg',
+    emergencyContact: [
+      {
+        firstName: 'Sarah',
+        lastName: 'Brown',
+        phone: '555-999-0000',
+        email: 'sarah.brown@example.com',
+        relationship: 'spouse'
+      },
+      {
+        firstName: 'David',
+        lastName: 'Brown',
+        phone: '555-222-3333',
+        email: 'david.brown@example.com',
+        relationship: 'father'
+      }
+    ]
   }
 ];
 

--- a/server/src/controllers/onboarding.ts
+++ b/server/src/controllers/onboarding.ts
@@ -1,99 +1,127 @@
-import Onboarding, { OnboardingTypeT } from "../models/Onboarding";
-import { Request, Response } from "express";
+import Onboarding, { OnboardingTypeT } from '../models/Onboarding';
+import { Request, Response } from 'express';
 
-import EmployeeUser from "../models/EmployeeUser";
-import { uploadFileToAWS } from "../utility/AWS/aws";
+import EmployeeUser from '../models/EmployeeUser';
+import PersonalInfo from '../models/PersonalInfo';
+import { onboardingToPersonalInfo } from './utils/converters';
+import { uploadFileToAWS } from '../utility/AWS/aws';
 
-const testOnboardingRouter =  (_req: Request, res: Response) => {
-  try{
+const testOnboardingRouter = (_req: Request, res: Response) => {
+  try {
     res.json('Successfully hit onboarding router');
-  }catch(err: unknown){
+  } catch (err: unknown) {
     console.log(`There was an error in the onboarding test route: ${err}`);
   }
 };
 
-const getOnboardingForUser = async(_req: Request, res: Response) => {
-  try{
-    const user = await EmployeeUser.findOne({username:"not onboarded user"});
-    
-    if(!user) throw Error('User not found');
-    
+const getOnboardingForUser = async (_req: Request, res: Response) => {
+  try {
+    const user = await EmployeeUser.findOne({ username: 'not onboarded user' });
+
+    if (!user) throw Error('User not found');
+
     let onboarding = await Onboarding.findById(user.onboardingId);
 
-    if(!onboarding){
-      onboarding = await Onboarding.create({userId: user._id})
-      user.onboardingId = onboarding._id
-      await user.save()
-    };
-    
+    if (!onboarding) {
+      onboarding = await Onboarding.create({ userId: user._id });
+      user.onboardingId = onboarding._id;
+      await user.save();
+    }
+
     res.json(onboarding);
-  }catch(err: unknown){
-    console.log(`There was an error getting the onboarding information: ${err}`);
+  } catch (err: unknown) {
+    console.log(
+      `There was an error getting the onboarding information: ${err}`
+    );
+    res.status(500).json({ message: `${err}` });
   }
 };
 
-const updateOnboardingForUser = async(req: Request, res: Response) => {
-  try{
+const updateOnboardingForUser = async (req: Request, res: Response) => {
+  try {
     const { updates }: { updates: Partial<OnboardingTypeT> } = req.body;
 
     //When auth is set up, we will get the user ID from the JWT and can replace this.
-    const user = await EmployeeUser.findOne({username:"not onboarded user"});
-    if(!user) throw Error('User not found');
-    
+    const user = await EmployeeUser.findOne({ username: 'michael.brown' });
+    if (!user) throw Error('User not found');
+
     const updatedOnboarding = await Onboarding.findByIdAndUpdate(
       user.onboardingId,
       {
         ...updates,
         status: 'pending'
-      }, 
+      },
       { new: true }
     );
 
     res.send(updatedOnboarding);
-  }catch(err: unknown){
+  } catch (err: unknown) {
     console.log(`There was an error updating the onboarding form: ${err}`);
   }
 };
 
-const updateOnboardingStatus = async(req: Request, res: Response) => {
-  try{
+const updateOnboardingStatus = async (req: Request, res: Response) => {
+  try {
     // need to check auth of the HR user for this route.
-    const { status, id }: { status: string, id: string } = req.body;
+    const { status, id }: { status: string; id: string } = req.body;
 
-    if(status !== 'approved' && status !== 'rejected') throw Error('Invalid status type.');
+    if (status !== 'approved' && status !== 'rejected')
+      throw Error('Invalid status type.');
 
-    const updatedOnboarding = await Onboarding.findByIdAndUpdate(id, { status }, { new: true });
-    
-    if(!updatedOnboarding) throw Error('The onboarding form was not found.');
-    
-    if(updatedOnboarding.status === 'approved'){
-      // create a new personal info for the user
-    };
-    
-    res.sendStatus(200);
-  }catch(err: unknown){
-    console.log(`There was an error updating the status of the onboarding: ${err}`);
+    const updatedOnboarding = await Onboarding.findByIdAndUpdate(
+      id,
+      { status },
+      { new: true }
+    ).select('+SSN');
+
+    if (!updatedOnboarding) throw Error('The onboarding form was not found.');
+
+    if (updatedOnboarding.status === 'approved') {
+      const user = await EmployeeUser.findById(updatedOnboarding.userId);
+      if (!user) throw Error('User not found');
+      if (user.personalInfoId) {
+        throw Error('User already has a personal info record');
+      }
+
+      const personalInfoData = onboardingToPersonalInfo(
+        updatedOnboarding,
+        user.email
+      );
+      const personalInfo = await PersonalInfo.create(personalInfoData);
+
+      user.personalInfoId = personalInfo._id;
+      await user.save();
+
+      res.status(200).json({
+        message: 'Onboarding approved and personal info created'
+      });
+    }
+  } catch (err: unknown) {
+    console.log(
+      `There was an error updating the status of the onboarding status: ${err}`
+    );
+    res.status(500).json({ message: `${err}` });
   }
 };
 
-const uploadOnboardingFile = async(req: Request, res: Response) => {
-  try{
-    const file = req.files?.file
-    
+const uploadOnboardingFile = async (req: Request, res: Response) => {
+  try {
+    const file = req.files?.file;
+
     // When onboarding model is updated, we can check if the document type is okay and then save the url on the user's onboarding.
     // const { type } = req.body
     // const user = EmployeeUser.findOne({ username: 'john.doe'})
-    
-    if(!file) throw Error('No file uploaded')
-    if(Array.isArray(file)) throw new Error('Only one file at a time')
-    
-    const url = await uploadFileToAWS(file)
-    
-    res.json(url)
-  }catch(err: unknown){
-    console.log(`There was an error uploading the file: ${err}`)
+
+    if (!file) throw Error('No file uploaded');
+    if (Array.isArray(file)) throw new Error('Only one file at a time');
+
+    const url = await uploadFileToAWS(file);
+
+    res.json(url);
+  } catch (err: unknown) {
+    console.log(`There was an error uploading the file: ${err}`);
   }
-}
+};
 
 export {
   testOnboardingRouter,

--- a/server/src/controllers/personalInfo.ts
+++ b/server/src/controllers/personalInfo.ts
@@ -1,8 +1,9 @@
-import PersonalInfo, { PersonalInfoTypeT } from "../models/PersonalInfo";
-import { Request, Response } from "express";
+import { Request, Response } from 'express';
 
-import EmployeeUser from "../models/EmployeeUser";
-import Onboarding from "../models/Onboarding";
+import EmployeeUser from '../models/EmployeeUser';
+import { IPersonalInfoData } from '../models/shared/types';
+import Onboarding from '../models/Onboarding';
+import PersonalInfo from '../models/PersonalInfo';
 
 // temp test user, await auth
 const currentTestUser = 'john.doe';
@@ -11,11 +12,9 @@ const testPersonalInfoRouter = (_req: Request, res: Response) => {
   try {
     res.json('Successfully hit personal info router');
   } catch (error) {
-    console.log(
-      `There was an error in the personal info test route: ${error}`
-    );
+    console.log(`There was an error in the personal info test route: ${error}`);
   }
-}
+};
 
 const getPersonalInfo = async (_req: Request, res: Response) => {
   try {
@@ -34,11 +33,11 @@ const getPersonalInfo = async (_req: Request, res: Response) => {
   } catch (error: unknown) {
     console.log(`Error fetching personal information: ${error}`);
   }
-}
+};
 
 const updatePersonalInfo = async (req: Request, res: Response) => {
   try {
-    const { updates }: { updates: Partial<PersonalInfoTypeT> } = req.body;
+    const { updates }: { updates: Partial<IPersonalInfoData> } = req.body;
     const user = await EmployeeUser.findOne({ username: currentTestUser });
     if (!user) throw Error('User not found');
 
@@ -57,10 +56,6 @@ const updatePersonalInfo = async (req: Request, res: Response) => {
   } catch (error: unknown) {
     console.log(`Error updating personal information: ${error}`);
   }
-}
+};
 
-export {
-  testPersonalInfoRouter,
-  getPersonalInfo,
-  updatePersonalInfo
-}
+export { testPersonalInfoRouter, getPersonalInfo, updatePersonalInfo };

--- a/server/src/controllers/utils/converters.ts
+++ b/server/src/controllers/utils/converters.ts
@@ -1,0 +1,15 @@
+import { Document } from 'mongoose';
+import { IPersonalInfoData } from '../../models/shared/types';
+import { OnboardingTypeT } from '../../models/Onboarding';
+
+export const onboardingToPersonalInfo = (
+  onboarding: Document & OnboardingTypeT,
+  email: string
+): Omit<IPersonalInfoData, '_id' | '__v'> => {
+  const { status, _id, __v, ...rest } = onboarding.toObject();
+
+  return {
+    ...rest,
+    email
+  };
+};

--- a/server/src/models/Onboarding.ts
+++ b/server/src/models/Onboarding.ts
@@ -1,10 +1,20 @@
-import mongoose, { InferSchemaType } from 'mongoose'
-
-const Schema = mongoose.Schema;
+import {
+  addressSchema,
+  carInfoSchema,
+  contactSchema,
+  driversLicenseSchema,
+  employmentSchema,
+  genderSchema,
+  nameSchema,
+  phoneSchema,
+  profilePictureSchema,
+  ssnSchema
+} from './shared/commonSchemas';
+import mongoose, { InferSchemaType, Schema } from 'mongoose';
 
 const OnboardingSchema = new Schema({
   userId: {
-    type: Schema.Types.ObjectId, 
+    type: Schema.Types.ObjectId,
     ref: 'EmployeeUser',
     required: true
   },
@@ -13,111 +23,24 @@ const OnboardingSchema = new Schema({
     enum: ['approved', 'rejected', 'pending'],
     default: 'pending'
   },
-  name: {
-    type: String,
-    default: ''
-  },
-  gender: {
-    type: String,
-    enum: ['male', 'female', 'other'],
-    default: null
-  },
-  dob: {
-    type: Date,
-    default: null
-  },
-  address: {
-    type: String, 
-    default: ''
-  },
-  phone: {
-    type: {
-      work: {
-        type: String,
-        default: ''
-      },
-      cell: {
-        type: String,
-        default: ''
-      }
-    }, 
-    default: {
-      work: '',
-      cell: ''
-    }
-  },
-  SSN: {
-    type: Number,
-    default: null
-  },
+  name: { type: nameSchema, required: true },
+  profilePicture: profilePictureSchema,
+  gender: genderSchema,
+  dob: { type: Date, required: true },
+  address: { type: addressSchema, required: true },
+  phone: { type: phoneSchema, required: true },
+  SSN: ssnSchema,
   carInfo: {
-    type: {
-      make: {
-        type: String,
-        default: ''
-      },
-      model: {
-        type: String,
-        default: ''
-      },
-      color: {
-        type: String,
-        default: ''
-      }
-    }, 
-    default: {
-      type: '',
-      model: '',
-      color: ''
-    }
+    type: carInfoSchema,
+    default: { make: null, model: null, color: null }
   },
-  driversLicense: {
-    type: String,
-    default: ''
-  },
-  residency: {
-    type: String,
-    enum: ['citizen', 'permanent resident', 'nonresident'],
-    default: null
-  },
-  documents: {
-    type: [{
-      type: String
-    }],
-    default: []
-  },
-  reference: {
-    type: {
-      firstName: String,
-      lastName: String,
-      middleName: String,
-      phone: String,
-      email: String,
-      relationship: String
-    },
-    default: null
-  },
-  emergencyContact: {
-    type: {
-      firstName: String,
-      lastName: String,
-      middleName: {
-        type: String,
-        default: ''
-      },
-      phone: String,
-      email: String,
-      relationship: String
-    },
-    default: null
-  },
-  profilePicture: {
-    type: String,
-    default: ''
-  }
+  driversLicense: driversLicenseSchema,
+  employment: { type: employmentSchema, required: true },
+  reference: { type: contactSchema, default: null },
+  emergencyContact: { type: [contactSchema], required: true }
 });
 
 const Onboarding = mongoose.model('Onboarding', OnboardingSchema);
 
-export type OnboardingTypeT = InferSchemaType<typeof OnboardingSchema>
+export type OnboardingTypeT = InferSchemaType<typeof OnboardingSchema>;
 export default Onboarding;

--- a/server/src/models/PersonalInfo.ts
+++ b/server/src/models/PersonalInfo.ts
@@ -1,72 +1,16 @@
-import mongoose, { Document, InferSchemaType, Schema } from 'mongoose';
-
-import { DEFAULT_PROFILE_PICTURE_ID } from './Document';
-
-interface IDriversLicense {
-  hasLicense: boolean;
-  number?: string;
-  expirationDate?: Date;
-  document?: mongoose.Types.ObjectId;
-}
-
-interface IPersonalInfo extends Document {
-  userId: mongoose.Types.ObjectId;
-  name: {
-    firstName: string;
-    lastName: string;
-    middleName?: string;
-    preferredName?: string;
-  };
-  email: string;
-  gender?: 'male' | 'female' | 'noAnswer';
-  dob: Date;
-  address: {
-    buildingNumber: string;
-    streetName: string;
-    city: string;
-    state: string;
-    zipCode: string;
-  };
-  phone: {
-    work?: string;
-    cell: string;
-  };
-  employment: {
-    residencyStatus: 'citizen' | 'greenCard' | 'nonresident';
-    visaType?: 'H1-B' | 'L2' | 'F1-CPT' | 'F1-OPT' | 'H4' | null;
-    startDate?: Date;
-    endDate?: Date;
-    documents: mongoose.Types.ObjectId[];
-  };
-  SSN: string;
-  carInfo?: {
-    make?: string;
-    model?: string;
-    color?: string;
-  };
-  driversLicense: IDriversLicense;
-  residency: 'citizen' | 'greenCard' | 'nonresident';
-  reference?: {
-    firstName: string;
-    lastName: string;
-    middleName?: string;
-    phone: string;
-    email: string;
-    relationship: string;
-  };
-  profilePicture?: mongoose.Types.ObjectId;
-  emergencyContacts: Array<{
-    firstName: string;
-    lastName: string;
-    middleName?: string;
-    phone: string;
-    email: string;
-    relationship: string;
-  }>;
-}
-
-// type ResidencyStatus = 'citizen' | 'greenCard' | 'nonresident';
-// type VisaType = 'H1-B' | 'L2' | 'F1-CPT' | 'F1-OPT' | 'H4' | null;
+import {
+  addressSchema,
+  carInfoSchema,
+  contactSchema,
+  driversLicenseSchema,
+  employmentSchema,
+  genderSchema,
+  nameSchema,
+  phoneSchema,
+  profilePictureSchema,
+  ssnSchema
+} from './shared/commonSchemas';
+import mongoose, { InferSchemaType, Schema } from 'mongoose';
 
 const PersonalInfoSchema = new Schema({
   userId: {
@@ -74,126 +18,25 @@ const PersonalInfoSchema = new Schema({
     ref: 'EmployeeUser',
     required: true
   },
-  name: {
-    firstName: { type: String, required: true },
-    lastName: { type: String, required: true },
-    middleName: { type: String, default: null },
-    preferredName: { type: String, default: null }
-  },
-  // NOTE: doc says email cannot be changed during onboarding,
-  // can it be changed in personal information page?
+  name: { type: nameSchema, required: true },
   email: {
     type: String,
     required: true
   },
-  gender: {
-    type: String,
-    enum: ['male', 'female', 'noAnswer'],
-    default: null
-  },
-  dob: {
-    type: Date,
-    required: true
-  },
-  address: {
-    buildingNumber: { type: String, required: true },
-    streetName: { type: String, required: true },
-    city: { type: String, required: true },
-    state: { type: String, required: true },
-    zipCode: { type: String, required: true }
-  },
-  phone: {
-    work: String,
-    cell: { type: String, required: true }
-  },
-  employment: {
-    residencyStatus: {
-      type: String,
-      enum: ['citizen', 'greenCard', 'nonresident'],
-      required: true
-    },
-    visaType: {
-      type: String,
-      enum: ['H1-B', 'L2', 'F1-CPT', 'F1-OPT', 'H4', null],
-      default: null
-    },
-    startDate: Date,
-    endDate: Date,
-    documents: [
-      {
-        type: Schema.Types.ObjectId,
-        ref: 'Document'
-      }
-    ]
-  },
-  // - select: by default, query will not return ssn,
-  // it has to be sepcified that ssn to be part of the
-  // response, which prevent accidental exposure
-  // - type: String because ssn likely needs to be
-  // encrypted, and String makes it easier to work with
-  SSN: {
-    type: String,
-    required: true,
-    select: false
-  },
+  gender: genderSchema,
+  dob: { type: Date, required: true },
+  address: { type: addressSchema, required: true },
+  phone: { type: phoneSchema, required: true },
+  SSN: ssnSchema,
+  employment: { type: employmentSchema, required: true },
   carInfo: {
-    make: String,
-    model: String,
-    color: String
+    type: carInfoSchema,
+    default: { make: null, model: null, color: null }
   },
-  driversLicense: {
-    hasLicense: { type: Boolean, required: true },
-    number: {
-      type: String,
-      required: function (this: IPersonalInfo) {
-        return this.driversLicense.hasLicense;
-      }
-    },
-    expirationDate: {
-      type: Date,
-      required: function (this: IPersonalInfo) {
-        return this.driversLicense.hasLicense;
-      }
-    },
-    document: {
-      type: Schema.Types.ObjectId,
-      ref: 'Document',
-      required: function (this: IPersonalInfo) {
-        return this.driversLicense.hasLicense;
-      }
-    }
-  },
-  // according to Joise in slack, reference can be anyone,
-  // not necessarily an employee, there can only be 1
-  // reference person
-  reference: {
-    type: {
-      firstName: { type: String, required: true },
-      lastName: { type: String, required: true },
-      middleName: { type: String, default: null },
-      phone: { type: String, required: true },
-      email: { type: String, required: true },
-      relationship: { type: String, required: true }
-    },
-    required: false,
-    default: null
-  },
-  profilePicture: {
-    type: Schema.Types.ObjectId,
-    ref: 'Document',
-    default: DEFAULT_PROFILE_PICTURE_ID
-  },
-  // a employee can have multiple emergency contacts
-  emergencyContacts: [
-    {
-      firstName: { type: String, required: true },
-      lastName: { type: String, required: true },
-      middleName: { type: String, default: null },
-      phone: { type: String, required: true },
-      email: { type: String, required: true },
-      relationship: { type: String, required: true }
-    }
-  ]
+  driversLicense: driversLicenseSchema,
+  reference: { type: contactSchema, default: null },
+  profilePicture: profilePictureSchema,
+  emergencyContact: { type: [contactSchema], required: true }
 });
 
 const PersonalInfo = mongoose.model('PersonalInfo', PersonalInfoSchema);

--- a/server/src/models/shared/commonSchemas.ts
+++ b/server/src/models/shared/commonSchemas.ts
@@ -1,0 +1,149 @@
+import { IDriversLicense, IEmployment } from './types';
+
+import { Schema } from 'mongoose';
+
+export const nameSchema = new Schema(
+  {
+    firstName: { type: String, required: true },
+    lastName: { type: String, required: true },
+    middleName: { type: String, default: null },
+    preferredName: { type: String, default: null }
+  },
+  { _id: false }
+);
+
+export const profilePictureSchema = {
+  type: Schema.Types.ObjectId,
+  ref: 'Document',
+  default: null
+};
+
+export const ssnSchema = {
+  type: String,
+  required: true,
+  select: false,
+  minlength: 9,
+  maxlength: 9
+};
+
+export const addressSchema = new Schema(
+  {
+    buildingNumber: { type: String, required: true },
+    streetName: { type: String, required: true },
+    city: { type: String, required: true },
+    state: { type: String, required: true },
+    zipCode: { type: String, required: true }
+  },
+  { _id: false }
+);
+
+export const phoneSchema = new Schema(
+  {
+    cell: { type: String, required: true },
+    work: { type: String, default: null }
+  },
+  { _id: false }
+);
+
+export const carInfoSchema = new Schema(
+  {
+    make: { type: String, default: null },
+    model: { type: String, default: null },
+    color: { type: String, default: null }
+  },
+  { _id: false }
+);
+
+export const genderSchema = {
+  type: String,
+  enum: ['male', 'female', 'noAnswer', null],
+  default: null
+};
+
+export const driversLicenseSchema = new Schema(
+  {
+    hasLicense: { type: Boolean, required: true, default: false },
+    number: {
+      type: String,
+      required: function (this: IDriversLicense) {
+        return this.hasLicense;
+      },
+      default: null
+    },
+    expirationDate: {
+      type: Date,
+      required: function (this: IDriversLicense) {
+        return this.hasLicense;
+      },
+      default: null
+    },
+    document: {
+      type: Schema.Types.ObjectId,
+      ref: 'Document',
+      required: function (this: IDriversLicense) {
+        return this.hasLicense;
+      },
+      default: null
+    }
+  },
+  { _id: false }
+);
+
+export const employmentSchema = new Schema(
+  {
+    residencyStatus: {
+      type: String,
+      enum: ['citizen', 'greenCard', 'nonresident'],
+      required: true
+    },
+    visaType: {
+      type: String,
+      enum: ['H1-B', 'L2', 'F1(CPT/OPT)', 'H4', 'Other', null],
+      required: function (this: IEmployment) {
+        return this.residencyStatus === 'nonresident';
+      },
+      default: null
+    },
+    otherVisaTitle: {
+      type: String,
+      required: function (this: IEmployment) {
+        return this.visaType === 'Other';
+      },
+      default: null
+    },
+    startDate: {
+      type: Date,
+      required: function (this: IEmployment) {
+        return this.residencyStatus === 'nonresident';
+      },
+      default: null
+    },
+    endDate: {
+      type: Date,
+      required: function (this: IEmployment) {
+        return this.residencyStatus === 'nonresident';
+      },
+      default: null
+    },
+    documents: {
+      type: [{ type: Schema.Types.ObjectId, ref: 'Document' }],
+      required: function (this: IEmployment) {
+        return this.visaType === 'F1(CPT/OPT)';
+      },
+      default: null
+    }
+  },
+  { _id: false }
+);
+
+export const contactSchema = new Schema(
+  {
+    firstName: { type: String, required: true },
+    lastName: { type: String, required: true },
+    middleName: { type: String, default: null },
+    phone: { type: String, required: true },
+    email: { type: String, required: true },
+    relationship: { type: String, required: true }
+  },
+  { _id: false }
+);

--- a/server/src/models/shared/types.ts
+++ b/server/src/models/shared/types.ts
@@ -1,0 +1,95 @@
+import mongoose, { Document, Types } from 'mongoose';
+
+export interface IEmployeeUserData {
+  username: string;
+  password: string;
+  email: string;
+  onboardingId: mongoose.Types.ObjectId | null;
+  personalInfoId: mongoose.Types.ObjectId | null;
+  visaApplicationId: mongoose.Types.ObjectId | null;
+  apartmentId: mongoose.Types.ObjectId | null;
+}
+
+export interface IEmployeeUser extends IEmployeeUserData, Document {
+  _id: Types.ObjectId;
+}
+
+export interface IName {
+  firstName: string;
+  lastName: string;
+  middleName?: string | null;
+  preferredName?: string | null;
+}
+
+export interface IPhone {
+  cell: string;
+  work?: string | null;
+}
+
+export interface IEmployment {
+  residencyStatus: 'citizen' | 'greenCard' | 'nonresident';
+  visaType?: 'H1-B' | 'L2' | 'F1(CPT/OPT)' | 'H4' | 'Other' | null;
+  otherVisaTitle?: string | null;
+  startDate?: Date | null;
+  endDate?: Date | null;
+  documents?: Types.ObjectId[] | null;
+}
+
+export interface IAddress {
+  buildingNumber: string;
+  streetName: string;
+  city: string;
+  state: string;
+  zipCode: string;
+}
+
+export interface IDriversLicense {
+  hasLicense: boolean;
+  number?: string | null;
+  expirationDate?: Date | null;
+  document?: Types.ObjectId | null;
+}
+
+export interface ICarInfo {
+  make?: string | null;
+  model?: string | null;
+  color?: string | null;
+}
+
+export interface IContact {
+  firstName: string;
+  lastName: string;
+  middleName?: string | null;
+  phone: string;
+  email: string;
+  relationship: string;
+}
+
+export interface IBasicInfoData {
+  userId: mongoose.Types.ObjectId;
+  name: IName;
+  profilePicture?: mongoose.Types.ObjectId;
+  gender?: 'male' | 'female' | 'noAnswer' | null;
+  dob: Date;
+  address: IAddress;
+  phone: IPhone;
+  employment: IEmployment;
+  SSN: string;
+  carInfo?: ICarInfo;
+  driversLicense: IDriversLicense;
+  reference?: IContact | null;
+  emergencyContact: IContact[];
+}
+
+export interface IBasicInfo extends IBasicInfoData, Document {}
+
+export interface IOnboardingData extends IBasicInfoData {
+  status: 'approved' | 'rejected' | 'pending';
+}
+
+export interface IPersonalInfoData extends IBasicInfoData {
+  email: string;
+}
+
+export interface IOnboarding extends IOnboardingData, Document {}
+export interface IPersonalInfo extends IPersonalInfoData, Document {}


### PR DESCRIPTION
- realign onboarding model with personal info model
- add more strict required fields and additional default values 
- extrapolate duplicated codes into /models/shared/commonSchemas.ts for both onboarding and personal info to share
- modify seeding logic accordingly
- add onboarding to personal info record conversion logic (/controllers/utils/convertors.ts), likely will be moved to /utility folder along with aws.ts
- test new code with onboarding and personal info routers with success

note: 
- i did not flatten onboarding or personal info, because the potential of causing problems in the current backend structure; i feel like frontend complexity improvements can be done without changing the schemas, so i left them largely unchaned
- /models/shared/types.ts was created purely for simple uses within models themselves to avoid type mismatches, i wrote it out completely in anticipation of potential usage elsewhere in the backend, which did not happen, as infer types are enough for most use cases, if needed, only a couple of the types needed to be kept