### PR TITLE
bug fix - move onboard record creation logic && minor format changes

### DIFF
--- a/server/src/controllers/personalInfo.ts
+++ b/server/src/controllers/personalInfo.ts
@@ -23,7 +23,7 @@ const getPersonalInfo = async (_req: Request, res: Response) => {
 
     const onboarding = await Onboarding.findById(user.onboardingId);
     if (!onboarding || onboarding.status !== 'approved') {
-      throw Error('User has not onboard yet');
+      throw Error('User has not onboarded yet');
     }
 
     const personalInfo = await PersonalInfo.findById(user.personalInfoId);
@@ -43,7 +43,7 @@ const updatePersonalInfo = async (req: Request, res: Response) => {
 
     const onboarding = await Onboarding.findById(user.onboardingId);
     if (!onboarding || onboarding.status !== 'approved') {
-      throw Error('User has not onboard yet');
+      throw Error('User has not onboarded yet');
     }
 
     const updateInfo = await PersonalInfo.findByIdAndUpdate(


### PR DESCRIPTION
Bug: after onboarding model refactor, when `getOnboardingForUser` is used, and the user does not have a onboarding record, it creates an empty onboarding record, which is blocked from entering the DB, because the additional required fields.

Solution: move the creation process to `updateOnboardingForUser`, which will be used when users finishes filling out the onboarding form, that way data from the frontend is enough to create a new onboarding record with all required fields filled. `getOnboardingForUser` will simply throw "User has not onboarded yet" if no onboarding record exists for said user.